### PR TITLE
Defines method to get callback_url

### DIFF
--- a/lib/omniauth/strategies/thirdparty_client_pacreception.rb
+++ b/lib/omniauth/strategies/thirdparty_client_pacreception.rb
@@ -27,7 +27,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info || access_token.get(api_path).parsed
+        @raw_info ||= access_token.get(api_path).parsed
       end
 
       def authorize_params
@@ -43,6 +43,10 @@ module OmniAuth
 
       def callback_path
         options[:callback_path] || super
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
 
       def prune!(hash)


### PR DESCRIPTION
Method `callback_url` was not defined. This causes `redirect_uri_mismatch` error while usage google oauth2